### PR TITLE
Fix pattern to get files only + Replace \ with / for Directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sarc = { git = "https://github.com/Coolsonickirby/sarc.git" }
+sarc = "1.2.0"
 zip = "0.5"
 structopt = "0.3.12"
 glob = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sarc = "1.1"
+sarc = { git = "https://github.com/Coolsonickirby/sarc.git" }
 zip = "0.5"
 structopt = "0.3.12"
 glob = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,11 @@ fn write(sarc: SarcFile, out_file: PathBuf, yaz0: bool, zstd: bool) {
 }
 
 fn zip(yaz0: bool, zstd: bool, in_dir: PathBuf, out_file: PathBuf, byte_order: Endian) {
-    let pattern = in_dir.to_string_lossy() + "/**/*";
+    let pattern = in_dir.to_string_lossy() + "/**/*.*";
     let dir = glob::glob(&pattern).unwrap();
     let files = dir.map(|child|{
         let path = child.unwrap();
-        let name = Some(path.strip_prefix(&in_dir).unwrap().to_string_lossy().into());
+        let name = Some(path.strip_prefix(&in_dir).unwrap().to_string_lossy().replace("\\", "/").into());
         let data = fs::read(path).unwrap();
 
         SarcEntry {


### PR DESCRIPTION
- Changed the glob pattern to get files only
- Replace \\ in path with / for proper directory support

Temporarily changed the `sarc` dependency in the `Cargo.toml` to point to my fork until the PR gets merged.